### PR TITLE
Leverage new script to run Web2py via py3 & bump changelog for v16.0.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,25 @@
+turnkey-web2py-16.0 (1) turnkey; urgency=low
+
+  * Latest upstream Web2py (via git) - v2.20.4.
+    [ Stefan Davis <stefan@turnkeylinux.org> ]
+
+  * Provider helper script; 'turnkey-web2py-pyver`. A script to switch running
+    Web2py between python2 & python3. This Web2py appliance defaults to
+    python3.
+
+  * Explcitly disable TLS<1.2 (i.e. SSLv3, TLSv1, TLSv1.1). (v15.x
+    TurnKey releases supported TLS 1.2, but could fallback as low as TLSv1).
+
+  * Update SSL/TLS cyphers to provide "Intermediate" browser/client support
+    (suitable for "General-purpose servers with a variety of clients,
+    recommended for almost all systems"). As provided by Mozilla via
+    https://ssl-config.mozilla.org/.
+
+  * Updated version of mysqltuner script - now installed as per upstream
+    recommendation.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 16 Jul 2020 16:06:23 +1000
+
 turnkey-web2py-15.1 (1) turnkey; urgency=low
 
   * Latest upstream version of Web2py (2.17.2).

--- a/conf.d/main
+++ b/conf.d/main
@@ -2,11 +2,13 @@
 
 W2PROOT=/var/www/web2py
 
+# set Web2py to use python3 by default
+turnkey-web2py-pyver py3
+
 # set welcome as web2py default application
 cat >$W2PROOT/routes.py<<EOF
-#!/usr/bin/python
+#!/usr/bin/env python
 default_application = 'welcome'
 EOF
 
 chown www-data:www-data $W2PROOT/routes.py
-


### PR DESCRIPTION
Web2py appliance v16.0 update.

Depends on https://github.com/turnkeylinux/common/pull/159